### PR TITLE
#3 - Update to be compatible with WPGraphQL v0.8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
     "require-dev": {
         "valu/wp-testing-tools": "^0.4.0",
-        "lucatume/wp-browser": "^2.2"
+        "lucatume/wp-browser": "^2.2",
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,15 @@
     "require-dev": {
         "valu/wp-testing-tools": "^0.4.0",
         "lucatume/wp-browser": "^2.2",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^8.0",
+        "codeception/module-asserts": "^1.0",
+        "codeception/module-phpbrowser": "^1.0",
+        "codeception/module-webdriver": "^1.0",
+        "codeception/module-db": "^1.0",
+        "codeception/module-filesystem": "^1.0",
+        "codeception/module-rest": "^1.0",
+        "codeception/module-cli": "^1.0",
+        "codeception/util-universalframework": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.wp-install.json
+++ b/composer.wp-install.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "composer/installers": "^1.0",
-        "wp-graphql/wp-graphql": "^0.6.0"
+        "wp-graphql/wp-graphql": "^0.8.3"
     },
     "extra": {
         "installer-paths": {

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -86,7 +86,14 @@ class Loader
     static function get_offset_nodes(AbstractConnectionResolver $resolver)
     {
         $size = self::get_page_size($resolver);
-        return array_slice($resolver->get_nodes(), 0, $size);
+
+        $nodes = [];
+
+        foreach ($resolver->get_ids() as $id) {
+            $nodes[$id] = $resolver->get_node_by_id($id);
+        }
+
+        return array_slice($nodes, 0, $size);
     }
 
     static function is_offset_resolver(AbstractConnectionResolver $resolver)

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -86,7 +86,7 @@ class Loader
     static function get_offset_nodes(AbstractConnectionResolver $resolver)
     {
         $size = self::get_page_size($resolver);
-        return array_slice($resolver->get_items(), 0, $size);
+        return array_slice($resolver->get_nodes(), 0, $size);
     }
 
     static function is_offset_resolver(AbstractConnectionResolver $resolver)
@@ -187,7 +187,7 @@ class Loader
 
         $page_info['offsetPagination'] = [
             'total' => $total,
-            'hasMore' => count($resolver->get_items()) > $size,
+            'hasMore' => count($resolver->get_ids()) > $size,
             'hasPrevious' => $offset > 0,
         ];
         return $page_info;

--- a/tests/wpunit/PageInfoTest.php
+++ b/tests/wpunit/PageInfoTest.php
@@ -22,7 +22,7 @@ class PageInfoTest extends \Codeception\TestCase\WPTestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        \WPGraphQL::__clear_schema();
+        \WPGraphQL::clear_schema();
     }
 
     function createPosts($count, $args = [])

--- a/tests/wpunit/PostObjectCursorTest.php
+++ b/tests/wpunit/PostObjectCursorTest.php
@@ -114,15 +114,15 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase
 
     private function deleteByMetaKey($key, $value)
     {
-        $args = array(
-            'meta_query' => array(
-                array(
+        $args = [
+            'meta_query' => [
+                [
                     'key' => $key,
                     'value' => $value,
                     'compare' => '=',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $query = new WP_Query($args);
 
@@ -179,7 +179,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase
         }, $second['data']['posts']['edges']);
 
         // Make correspondig WP_Query
-        WPGraphQL::__set_is_graphql_request(true);
+        WPGraphQL::set_is_graphql_request(true);
         $first_page = new WP_Query(
             array_merge($meta_fields, [
                 'post_status' => 'publish',
@@ -199,7 +199,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase
                 'paged' => 2,
             ])
         );
-        WPGraphQL::__set_is_graphql_request(true);
+        WPGraphQL::set_is_graphql_request(true);
 
         $first_page_expected = wp_list_pluck($first_page->posts, 'ID');
         $second_page_expected = wp_list_pluck($second_page->posts, 'ID');

--- a/tests/wpunit/PostPaginationTest.php
+++ b/tests/wpunit/PostPaginationTest.php
@@ -22,7 +22,7 @@ class PostPaginationTest extends \Codeception\TestCase\WPTestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        \WPGraphQL::__clear_schema();
+        \WPGraphQL::clear_schema();
     }
 
     function createPosts($count, $args = [])

--- a/tests/wpunit/UserPaginationTest.php
+++ b/tests/wpunit/UserPaginationTest.php
@@ -10,7 +10,7 @@ class UserPaginationTest extends \Codeception\TestCase\WPTestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        \WPGraphQL::__clear_schema();
+        \WPGraphQL::clear_schema();
     }
 
     function createUsers($count, $args = [])


### PR DESCRIPTION
This PR brings things up to speed with WPGraphQL v0.8.3

**Note that WPGraphQL v0.8.0, v0.8.1 and v0.8.2 won't work with this plugin**, because I foolishly made some methods protected in the v0.8.0 release which effectively made it so they couldn't be used from within filters like this plugin uses. 🤦‍♂️ 