### PR TITLE
Fix Issues #8 and #11

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -87,7 +87,7 @@ class Loader
      * selection set.
      */
     function op_filter_graphql_connection_query_args(
-        array $query_args,
+        $query_args,
         AbstractConnectionResolver $resolver
     ) {
         $info = $resolver->getInfo();


### PR DESCRIPTION
**Fixes Bug:** Argument 1 passed to WPGraphQL\Extensions\OffsetPagination\Loader::op_filter_graphql_connection_query_args() must be of the type array, null given

**Bug Occurs:** When roles, enqueuedScripts, enqueuedStyleshets, or any other unaccounted for subquery is added because null parameter is not allowed by type definition, removing type definition fixes the issue.