### PR TITLE
Replase getArgs -> get_args

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -72,13 +72,13 @@ class Loader
      */
     static function get_page_size(AbstractConnectionResolver $resolver)
     {
-        $args = $resolver->getArgs();
+        $args = $resolver->get_args();
         return intval($args['where']['offsetPagination']['size'] ?? 0);
     }
 
     static function is_offset_resolver(AbstractConnectionResolver $resolver)
     {
-        $args = $resolver->getArgs();
+        $args = $resolver->get_args();
         return isset($args['where']['offsetPagination']);
     }
 
@@ -126,7 +126,7 @@ class Loader
     ) {
         $size = self::get_page_size($resolver);
         $query = $resolver->get_query();
-        $args = $resolver->getArgs();
+        $args = $resolver->get_args();
         $offset = $args['where']['offsetPagination']['offset'] ?? 0;
 
         $total = null;


### PR DESCRIPTION
To prevent this warning:

`[07-Mar-2023 20:32:50 UTC] PHP Deprecated:  Function WPGraphQL\Data\Connection\AbstractConnectionResolver::getArgs is <strong>deprecated</strong> since version 1.11.0! Use WPGraphQL\Data\Connection\PostObjectConnectionResolver::get_args() instead. in /app/wordpress/wp-includes/functions.php on line 5383`