### PR TITLE
fix deprecated getArgs, getInfo, ${}

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -72,13 +72,13 @@ class Loader
      */
     static function get_page_size(AbstractConnectionResolver $resolver)
     {
-        $args = $resolver->getArgs();
+        $args = $resolver->get_args();
         return intval($args['where']['offsetPagination']['size'] ?? 0);
     }
 
     static function is_offset_resolver(AbstractConnectionResolver $resolver)
     {
-        $args = $resolver->getArgs();
+        $args = $resolver->get_args();
         return isset($args['where']['offsetPagination']);
     }
 
@@ -90,7 +90,7 @@ class Loader
         $query_args,
         AbstractConnectionResolver $resolver
     ) {
-        $info = $resolver->getInfo();
+        $info = $resolver->get_info();
         $selection_set = $info->getFieldSelection(2);
 
         if (!isset($selection_set['pageInfo']['offsetPagination']['total'])) {
@@ -112,10 +112,10 @@ class Loader
     static function add_post_type_fields(\WP_Post_Type $post_type_object)
     {
         $type = ucfirst($post_type_object->graphql_single_name);
-        register_graphql_fields("RootQueryTo${type}ConnectionWhereArgs", [
+        register_graphql_fields("RootQueryTo{$type}ConnectionWhereArgs", [
             'offsetPagination' => [
                 'type' => 'OffsetPagination',
-                'description' => "Paginate ${type}s with offsets",
+                'description' => "Paginate {$type}s with offsets",
             ],
         ]);
     }
@@ -126,7 +126,7 @@ class Loader
     ) {
         $size = self::get_page_size($resolver);
         $query = $resolver->get_query();
-        $args = $resolver->getArgs();
+        $args = $resolver->get_args();
         $offset = $args['where']['offsetPagination']['offset'] ?? 0;
 
         $total = null;


### PR DESCRIPTION
```
[08-Aug-2024 15:58:38 UTC] PHP Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/wp-content/plugins/wp-graphql-offset-pagination-master/src/Loader.php on line 118

[08-Aug-2024 15:58:40 UTC] PHP Deprecated: Function WPGraphQL\Data\Connection\AbstractConnectionResolver::getArgs is deprecated since version 1.11.0! Use WPGraphQL\Data\Connection\TermObjectConnectionResolver::get_args() instead. in /var/www/html/wp-includes/functions.php on line 6085

[08-Aug-2024 15:58:40 UTC] PHP Deprecated: Function WPGraphQL\Data\Connection\AbstractConnectionResolver::getInfo is deprecated since version 1.24.0! Use WPGraphQL\Data\Connection\TermObjectConnectionResolver::get_info() instead. in /var/www/html/wp-includes/functions.php on line 6085
```